### PR TITLE
Around hooks (AKA callbacks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.0
+
+  - [feature] Now you can wrap around all steps, each step, all tasks, each task, all catches, or each catch.
+  - [feature] Step objects now have a receiver so we can know what the step was supposed to run against
+
 ## 2.0.0
 
   - [breaking] We now use methods instead of passing around procs defined with `step()`, we now use methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.0.0
 
   - [breaking] We now use methods instead of passing around procs defined with `step()`, we now use methods
-  - [breaking] Since we don't use procs, we can't use reciever or as, now it's just up to the step to do delgation
+  - [breaking] Since we don't use procs, we can't use receiver or as, now it's just up to the step to do delegation
   - [breaking] renamed the `state()` function to be called `schema()`
   - [breaking] `error` listings are now defined with `catch`
   - [breaking] `error`'s no longer have a receiver or an as property

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ end
 
 Add this line to your application's Gemfile:
 
-    gem "action_operation", "2.0.0"
+    gem "action_operation", "2.1.0"
 
 And then execute:
 

--- a/lib/action_operation.rb
+++ b/lib/action_operation.rb
@@ -27,7 +27,7 @@ module ActionOperation
       raise Error::MissingTask, step unless respond_to?(step.name)
       raise Error::MissingSchema, step unless self.class.schemas.key?(step.name)
 
-      # NOTE: We only care about this so we can refernece it in the rescue
+      # NOTE: We only care about this so we can reference it in the rescue
       @latest_step = step
 
       value = public_send(step.name, state: self.class.schemas.fetch(step.name).new(state))

--- a/lib/action_operation.rb
+++ b/lib/action_operation.rb
@@ -11,8 +11,8 @@ module ActionOperation
 
   State = Struct.new(:raw)
   Drift = Struct.new(:to)
-  Task = Struct.new(:name, :required)
-  Catch = Struct.new(:name, :exception)
+  Task = Struct.new(:name, :receiver, :required)
+  Catch = Struct.new(:name, :receiver, :exception)
 
   def initialize(raw:)
     raise ArgumentError, "needs to be a Hash" unless raw.kind_of?(Hash)
@@ -92,11 +92,11 @@ module ActionOperation
     end
 
     def task(name, required: true)
-      right << Task.new(name, required)
+      right << Task.new(name, self, required)
     end
 
     def catch(name, exception: StandardError)
-      left << Catch.new(name, exception)
+      left << Catch.new(name, self, exception)
     end
 
     def right

--- a/lib/action_operation.rb
+++ b/lib/action_operation.rb
@@ -24,8 +24,8 @@ module ActionOperation
     right.from(start || 0).reduce(raw) do |state, step|
       next state unless step.required || (start && right.at(start) == step)
 
-      raise Error::MissingTask, step unless respond_to?(step.name)
-      raise Error::MissingSchema, step unless self.class.schemas.key?(step.name)
+      raise Error::MissingTask, step: step unless respond_to?(step.name)
+      raise Error::MissingSchema, step: step unless self.class.schemas.key?(step.name)
 
       # NOTE: We only care about this so we can reference it in the rescue
       @latest_step = step

--- a/lib/action_operation.rb
+++ b/lib/action_operation.rb
@@ -20,7 +20,27 @@ module ActionOperation
     @raw = raw
   end
 
+  private def callbackings(arounds, &process)
+    arounds.reverse.reduce(process) do |compound, callback|
+      callback.call(&compound).call
+    end.call
+  end
+
   def call(start: nil, raw: @raw)
+    around_steps do
+      begin
+        around_tasks do
+          tasks(start, raw)
+        end
+      rescue *left.select(&:exception).map(&:exception).uniq => handled_exception
+        around_catches do
+          catches(handled_exception, raw)
+        end
+      end
+    end
+  end
+
+  private def tasks(start, raw)
     right.from(start || 0).reduce(raw) do |state, step|
       next state unless step.required || (start && right.at(start) == step)
 
@@ -30,21 +50,42 @@ module ActionOperation
       # NOTE: We only care about this so we can reference it in the rescue
       @latest_step = step
 
-      value = public_send(step.name, state: self.class.schemas.fetch(step.name).new(state))
+      # puts "#{step.class}::#{step.receiver}##{step.name}"
+
+      begin
+        value = around_task do
+          public_send(step.name, state: self.class.schemas.fetch(step.name).new(state))
+        end
+        # puts "#{step.class}::#{step.receiver}##{step.name} #{value}"
+      rescue SmartParams::Error::InvalidPropertyType => invalid_property_type_exception
+        raise Error::StepSchemaMismatch, step: step, schema: self.class.schemas.fetch(step.name), raw: raw, cause: invalid_property_type_exception
+      end
+
 
       case value
-      when State then value.raw
-      when Drift then break call(start: right.find_index { |step| step.name == value.to }, raw: raw)
-      else state
+        when State then value.raw
+        when Drift then break call(start: right.find_index { |step| step.name == value.to }, raw: state)
+        else state
       end
     end
-  rescue *left.select(&:exception).map(&:exception).uniq => handled_exception
-    left.select do |failure|
-      failure.exception === handled_exception
-    end.reduce(handled_exception) do |exception, step|
-      raise Error::MissingError, step unless respond_to?(step.name)
+  end
 
-      value = public_send(step.name, exception: exception, state: self.class.schemas.fetch(@latest_step.name).new(raw), step: @latest_step)
+  private def catches(exception, raw)
+    left.select do |failure|
+      failure.exception === exception
+    end.reduce(exception) do |exception, step|
+      raise Error::MissingError, step: step unless respond_to?(step.name)
+
+      # puts "#{step.class}::#{step.receiver}##{step.name}"
+
+      begin
+        value = around_catch do
+          public_send(step.name, exception: exception, state: raw, step: @latest_step)
+        end
+        # puts "#{step.class}::#{step.receiver}##{step.name} #{value}"
+      rescue SmartParams::Error::InvalidPropertyType => invalid_property_type_exception
+        raise Error::StepSchemaMismatch, step: @latest_step, schema: self.class.schemas.fetch(@latest_step.name), raw: raw, cause: invalid_property_type_exception
+      end
 
       if value.kind_of?(Drift)
         break call(start: right.find_index { |step| step.name == value.to }, raw: raw)
@@ -64,6 +105,30 @@ module ActionOperation
     raise ArgumentError, "needs to be a Symbol or String" unless to.kind_of?(Symbol) || to.kind_of?(String)
 
     Drift.new(to)
+  end
+
+  def around_steps(&callback)
+    callback.call
+  end
+
+  def around_step(&callback)
+    callback.call
+  end
+
+  def around_tasks(&callback)
+    callback.call
+  end
+
+  def around_task(&callback)
+    callback.call
+  end
+
+  def around_catches(&callback)
+    callback.call
+  end
+
+  def around_catch(&callback)
+    callback.call
   end
 
   private def left

--- a/lib/action_operation/error.rb
+++ b/lib/action_operation/error.rb
@@ -3,5 +3,6 @@ module ActionOperation
     require_relative "error/missing_error"
     require_relative "error/missing_schema"
     require_relative "error/missing_task"
+    require_relative "error/step_schema_mismatch"
   end
 end

--- a/lib/action_operation/error/missing_error.rb
+++ b/lib/action_operation/error/missing_error.rb
@@ -1,7 +1,7 @@
 module ActionOperation
   class Error
     class MissingError < Error
-      def initialize(step)
+      def initialize(step:)
         @step = step
       end
 

--- a/lib/action_operation/error/missing_schema.rb
+++ b/lib/action_operation/error/missing_schema.rb
@@ -1,7 +1,7 @@
 module ActionOperation
   class Error
     class MissingSchema < Error
-      def initialize(step)
+      def initialize(step:)
         @step = step
       end
 

--- a/lib/action_operation/error/missing_task.rb
+++ b/lib/action_operation/error/missing_task.rb
@@ -1,7 +1,7 @@
 module ActionOperation
   class Error
     class MissingTask < Error
-      def initialize(step)
+      def initialize(step:)
         @step = step
       end
 

--- a/lib/action_operation/error/step_schema_mismatch.rb
+++ b/lib/action_operation/error/step_schema_mismatch.rb
@@ -1,0 +1,15 @@
+module ActionOperation
+  class Error
+    class StepSchemaMismatch < Error
+      def initialize(step:, schema:, raw:)
+        @step = step
+        @schema = schema
+        @raw = raw
+      end
+
+      def message
+        "#{@step.receiver}##{@step.name} #{cause.message} and received #{@raw}"
+      end
+    end
+  end
+end

--- a/lib/action_operation/version.rb
+++ b/lib/action_operation/version.rb
@@ -1,3 +1,3 @@
 module ActionOperation
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end

--- a/lib/action_operation_spec.rb
+++ b/lib/action_operation_spec.rb
@@ -1,10 +1,10 @@
 require "spec_helper"
 
 RSpec.describe ActionOperation do
-  let(:operation) { DocumentUploadOperation }
+  let(:operation) { DocumentUploadOperation.new(raw: arguments) }
 
   describe "#call" do
-    subject { operation.call(arguments) }
+    subject { operation.call }
 
     context "with the right arguments" do
       let(:arguments) {{document: Document.new}}

--- a/lib/action_operation_spec.rb
+++ b/lib/action_operation_spec.rb
@@ -3,11 +3,21 @@ require "spec_helper"
 RSpec.describe ActionOperation do
   let(:operation) { DocumentUploadOperation.new(raw: arguments) }
 
+  before do
+    allow(operation).to receive(:logger)
+  end
+
   describe "#call" do
     subject { operation.call }
 
     context "with the right arguments" do
       let(:arguments) {{document: Document.new}}
+
+      it "calls the around steps callback" do
+        expect(operation).to receive(:logger).twice
+
+        subject
+      end
 
       it "works" do
         expect(subject).to match(hash_including(document: a_kind_of(Document), location: "some.s3"))

--- a/spec/support/document_upload_operation.rb
+++ b/spec/support/document_upload_operation.rb
@@ -6,6 +6,13 @@ class DocumentUploadOperation < ApplicationOperation
   catch :retry, exception: FailedUploadError
   catch :reraise
 
+  def around_steps
+    logger("around_steps/before")
+    yield.tap do
+      logger("around_steps/after")
+    end
+  end
+
   schema :upload_to_s3 do
     field :document, type: Types.Instance(Document)
   end
@@ -45,5 +52,9 @@ class DocumentUploadOperation < ApplicationOperation
     when :upload_to_s3 then drift(to: :upload_to_azure)
     when :upload_to_azure then drift(to: :upload_to_spaces)
     end
+  end
+
+  def logger(message)
+    puts(message)
   end
 end


### PR DESCRIPTION
### Callbacks
 
Sometimes we want to make sure an operation or it's individual parts are wrapped in safety measures, like a transaction or a timeout. You can achieve these with special built in instance methods. I'll show you each one and why you would use it.
 
To start, the highest wrapper is `around_steps`, which wraps around both tasks and catches. A good use for this is
 
``` ruby
class AddProductToCart < ApplicationOperation
  def around_steps(raw:)
    Rails.logger.tagged("operation-id=#{SecureRandom.uuid}") do
      Rails.logger.debug("Started adding cart to product operation with (#{raw.to_json})")
 
      yield
    end
  end
end
```
 
Here we're making sure every log we write will be tagged with a unique identifier for the entire operation, an extremely valuable option for debugging. The `around_steps` hook will be told about the raw data it receives in the call (`AddProductToCart.({cart: current_cart, product: product})`).
 
While `around_steps` is on the entire operation, you might want individual wrapping. Let me present: `around_step`!
 
``` ruby
class AddProductToCart < ApplicationOperation
  def around_step(step:)
    Rails.logger.tagged("step-id=#{SecureRandom.uuid}") do
      yield
    end
  end
end
```
 
This `around_step` will give you a per-step unique id tag for all logs in a step, another fantastic tool in debugging. This hook will be told of the `Task|Catch` object which responds to `#name` and `#receiver`. Additionally a `Task` responds to `#required` and a `Catch` responds to `#exception`.
 
Finally, there are 4 other type specific hooks: `around_tasks`, `around_task`, `around_catches`, and `around_catch`. Here are example uses:
 
 
``` ruby
class AddProductToCart < ApplicationOperation
  def around_tasks
    Timeout.new(30.seconds) do
      yield
    end
  end
 
  def around_task(step:, state:)
    Rails.logger.debug("Working on #{step.receiver}##{step.name} using (#{state.to_json})")
 
    Timeout.new(10.seconds) do
      ApplicationRecord.transaction do
        yield
      end
    end
  end
end
```